### PR TITLE
Add default value to RequestMatcherInterface:matches() and fix a typo.

### DIFF
--- a/EventSubscriber/IOEventSubscriber.php
+++ b/EventSubscriber/IOEventSubscriber.php
@@ -139,7 +139,7 @@ class IOEventSubscriber implements EventSubscriberInterface
      */
     protected function eventRequestMatches(KernelEvent $event)
     {
-        return $this->requestMatcher->matches($event->getRequest(), $event->getRequestType());
+        return $this->requestMatcher->matches($event->getRequest());
     }
 
     /**

--- a/Request/RequestMatcher.php
+++ b/Request/RequestMatcher.php
@@ -32,15 +32,10 @@ class RequestMatcher implements RequestMatcherInterface
 
     /**
      * @param Request $request
-     * @param int $requestType
      * @return bool
      */
-    public function matches(Request $request, $requestType = HttpKernelInterface::MASTER_REQUEST)
+    public function matches(Request $request)
     {
-        if ($requestType !== HttpKernelInterface::MASTER_REQUEST) {
-            return false;
-        }
-
         if ($this->matchPreviouslyMatchedRequest($request)) {
             return true;
         }

--- a/Request/RequestMatcherInterface.php
+++ b/Request/RequestMatcherInterface.php
@@ -6,5 +6,5 @@ use Symfony\Component\HttpFoundation\Request;
 
 interface RequestMatcherInterface
 {
-    public function matches(Request $request, $requestTYpe);
+    public function matches(Request $request);
 }

--- a/Tests/Request/RequestMatcherTest.php
+++ b/Tests/Request/RequestMatcherTest.php
@@ -13,14 +13,12 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
     {
         $matcher = new RequestMatcher([]);
         foreach ([
-                     ['path' => '/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/bar', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/foo', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
-                     ['path' => '/bar', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
+                     ['path' => '/foo', 'result' => false],
+                     ['path' => '/bar', 'result' => false],
                  ] as $test
         ) {
             $this->assertEquals($test['result'],
-                $matcher->matches($this->getRequestFromPath($test['path']), $test['type']));
+                $matcher->matches($this->getRequestFromPath($test['path'])));
         }
     }
 
@@ -31,19 +29,17 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
             '~^/api/~'
         ]);
         foreach ([
-                     ['path' => '/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/fapi', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/api', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
-                     ['path' => '/api', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
-                     ['path' => '/api/', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
-                     ['path' => '/api/', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
-                     ['path' => '/api/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
-                     ['path' => '/api/doc', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
+                     ['path' => '/foo', 'result' => false],
+                     ['path' => '/foo', 'result' => false],
+                     ['path' => '/fapi', 'result' => false],
+                     ['path' => '/api', 'result' => true],
+                     ['path' => '/api/', 'result' => true],
+                     ['path' => '/api/foo', 'result' => true],
+                     ['path' => '/api/doc', 'result' => true],
                  ] as $test
         ) {
             $this->assertEquals($test['result'],
-                $matcher->matches($this->getRequestFromPath($test['path']), $test['type']));
+                $matcher->matches($this->getRequestFromPath($test['path'])));
         }
     }
 
@@ -56,20 +52,17 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
             '~^/api/doc~'
         ]);
         foreach ([
-                     ['path' => '/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/fapi', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/api', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
-                     ['path' => '/api', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
-                     ['path' => '/api/', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
-                     ['path' => '/api/', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
-                     ['path' => '/api/foo', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => true],
-                     ['path' => '/api/doc', 'type' => HttpKernelInterface::MASTER_REQUEST, 'result' => false],
-                     ['path' => '/api/doc', 'type' => HttpKernelInterface::SUB_REQUEST, 'result' => false],
+                     ['path' => '/foo', 'result' => false],
+                     ['path' => '/foo', 'result' => false],
+                     ['path' => '/fapi', 'result' => false],
+                     ['path' => '/api', 'result' => true],
+                     ['path' => '/api/', 'result' => true],
+                     ['path' => '/api/foo', 'result' => true],
+                     ['path' => '/api/doc', 'result' => false],
                  ] as $test
         ) {
             $this->assertEquals($test['result'],
-                $matcher->matches($this->getRequestFromPath($test['path']), $test['type']));
+                $matcher->matches($this->getRequestFromPath($test['path'])));
         }
     }
 


### PR DESCRIPTION
IDEs complain if the RequestMatcher service is defined as its interface and you do not use the second parameter.

![default_value](https://cloud.githubusercontent.com/assets/1186954/20390573/4de93000-acae-11e6-9f9a-193004274810.jpg)
