### PR TITLE
Remove unnecessary response_model_dependency

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -24,7 +24,6 @@
             <argument type="service" id="mediamonks_rest_api.regex_request_matcher"/>
             <argument type="service" id="mediamonks_rest_api.request_transformer"/>
             <argument type="service" id="mediamonks_rest_api.response_transformer"/>
-            <argument type="service" id="mediamonks_rest_api.response_model_factory"/>
         </service>
         <service id="mediamonks_rest_api.regex_request_matcher" class="%mediamonks_rest_api.regex_request_matcher.class%">
             <argument type="collection"/>


### PR DESCRIPTION
ResponseModelFactory is not a dependency in RestApiEventSubscriber, but it is still provided in services.xml: https://github.com/mediamonks/php-rest-api/blob/master/src/EventSubscriber/RestApiEventSubscriber.php#L38